### PR TITLE
Make sure agent/env arguments are forwarded

### DIFF
--- a/rllm/trainer/verl/agent_ppo_trainer.py
+++ b/rllm/trainer/verl/agent_ppo_trainer.py
@@ -97,13 +97,16 @@ class AgentPPOTrainer(RayPPOTrainer):
         """
         env_args = batch.non_tensor_batch["extra_info"].tolist()
 
+        full_agent_args = dict(self.config.agent.get("agent_args", {})) | self.agent_args
+        base_env_args = dict(self.config.env.get("env_args", {})) | self.env_args
+
         def _create_env(i):
             if isinstance(env_args[i], str):
                 env_args[i] = json.loads(env_args[i])
-            return i, self.env_class.from_dict({**env_args[i], **self.config.env.get("env_args", {})})
+            return i, self.env_class.from_dict({**env_args[i], **base_env_args})
 
         def _create_agent(i):
-            return i, self.agent_class(**self.config.agent.get("agent_args", {}))
+            return i, self.agent_class(**full_agent_args)
 
         # Create environments in parallel while preserving order
         envs = [None] * len(env_args)


### PR DESCRIPTION
Hi, thank you for open sourcing a very clean code base! I was trying to run the `math_tools` example following the [README](https://github.com/agentica-project/rllm/tree/main/examples/math_tool#training), when I noticed that the tool schemas were not being passed to either the agent or the environment (see screenshot below). It appears that `init_envs_and_agents` ignores the `{env,agent}_args` passed to the init.

This is fixed by this PR, but perhaps I am missing the bigger picture. 

![image](https://github.com/user-attachments/assets/37c93d93-d46e-48ea-8933-b761f6cb9e12)
